### PR TITLE
Reperforming rigid registration

### DIFF
--- a/RigidDeformation.py
+++ b/RigidDeformation.py
@@ -36,7 +36,7 @@ def perform_rigid_registration(fixed_image, moving_image, output_path, mask_name
             # Initialization
             initial_transform = sitk.CenteredTransformInitializer(fixed_image,
                                                                 moving_image,
-                                                                sitk.Euler3DTransform(),
+                                                                sitk.Rigid3DTransform(),
                                                                 sitk.CenteredTransformInitializerFilter.GEOMETRY)
             registration_method.SetInitialTransform(initial_transform, inPlace=False)
 


### PR DESCRIPTION
Rigid Transformation: You have replaced sitk.Euler3DTransform() with sitk.Rigid3DTransform() which is a more direct representation of a rigid transformation. This should produce a .tfm file that represents a rigid transformation.