### PR TITLE
Update apply_transformations.py

### DIFF
--- a/apply_transformations.py
+++ b/apply_transformations.py
@@ -12,7 +12,6 @@ def parse_dat_file(dat_file_path):
                 label = int(parts[0])
                 hu_value = float(parts[1])
                 label_to_hu[label] = hu_value
-                print(f"Mapping label {label} to HU value {hu_value}")
     return label_to_hu
 
 def read_transform_parameters(transform_path):
@@ -22,8 +21,7 @@ def read_transform_parameters(transform_path):
         for line in lines:
             if 'Parameters:' in line:
                 parameters = line.split(':')[1].strip().split(' ')
-                parameters = [float(p) for p in parameters]
-                return parameters
+                return [float(p) for p in parameters]
     except FileNotFoundError:
         print(f"Transformation file not found: {transform_path}")
     return None
@@ -37,42 +35,39 @@ def apply_rigid_body_transformation(image, parameters, transform_name, output_pa
 def save_transformed_image(transformed_image, transform_name, output_path):
     transformed_image_path = os.path.join(output_path, f"{transform_name}_transformed.mha")
     sitk.WriteImage(transformed_image, transformed_image_path)
-    print(f"Transformed image saved at {transformed_image_path}")
 
-def map_to_hu_values(label_image, label_to_hu, output_path):
+def map_to_hu_values(label_image, label_to_hu):
     label_array = sitk.GetArrayFromImage(label_image)
     hu_mapped_array = np.copy(label_array)
     for label, hu_value in label_to_hu.items():
         hu_mapped_array[label_array == label] = hu_value
     hu_mapped_image = sitk.GetImageFromArray(hu_mapped_array)
     hu_mapped_image.CopyInformation(label_image)
-    hu_mapped_image_path = os.path.join(output_path, "hu_mapped_labels.mha")
-    sitk.WriteImage(hu_mapped_image, hu_mapped_image_path)
-    print(f"HU-mapped label image saved at {hu_mapped_image_path}")
+    return hu_mapped_image
 
 def load_patient_ct_scan(directory_path):
     reader = sitk.ImageSeriesReader()
     dicom_names = reader.GetGDCMSeriesFileNames(directory_path)
+    if not dicom_names:
+        print(f"No DICOM series found in directory: {directory_path}")
+        return None
     reader.SetFileNames(dicom_names)
     try:
-        image = reader.Execute()
+        return reader.Execute()
     except RuntimeError as e:
-        print(f"RuntimeError: {e}")
-        print(f"Could not load DICOM series from directory: {directory_path}")
+        print(f"Error reading DICOM series from {directory_path}: {e}")
         return None
-    return image
 
 def apply_transformations(patient_directory, labels_directory, dat_file_path, label_filename="labels.mha"):
-    # Load and apply transformation to patient CT scan
     patient_ct_image = load_patient_ct_scan(patient_directory)
+    if patient_ct_image is None:
+        return
 
-    # Apply transformation to labels
     label_path = os.path.join(labels_directory, label_filename)
     label_image = sitk.ReadImage(label_path)
     label_to_hu = parse_dat_file(dat_file_path)
-    hu_mapped_label_image = map_to_hu_values(label_image, label_to_hu, patient_directory)
+    hu_mapped_label_image = map_to_hu_values(label_image, label_to_hu)
 
-    # Read transform parameters and apply rigid body transformation
     transform_path = os.path.join(patient_directory, "rigid_transformation.tfm")
     parameters = read_transform_parameters(transform_path)
     if parameters:
@@ -81,13 +76,12 @@ def apply_transformations(patient_directory, labels_directory, dat_file_path, la
 
 if __name__ == "__main__":
     if len(sys.argv) < 4:
-        print("Usage: python apply_transformations.py [patient_directory] [labels_directory] [dat_file_path]")
+        print("Usage: python apply_transformations.py [patient_directories] [labels_directory] [dat_file_path]")
         sys.exit(1)
 
-    patient_directories = ["Patient_CT_Scan_1", "Patient_CT_Scan_2", "Patient_CT_Scan_3", "Patient_CT_Scan_4"]
+    patient_directories = sys.argv[1].split(',')  # Expecting a comma-separated list of patient directories
     labels_directory = sys.argv[2]
     dat_file_path = sys.argv[3]
 
     for patient_directory in patient_directories:
         apply_transformations(patient_directory, labels_directory, dat_file_path)
-


### PR DESCRIPTION
the patient directories are expected to be passed as a comma-separated list (e.g., "Patient_CT_Scan_1,Patient_CT_Scan_2,Patient_CT_Scan_3"). The code will iterate over each directory, applying the transformations to both the patient's CT scan and the corresponding labels. It includes error checks to handle issues with loading DICOM series or reading transform parameters